### PR TITLE
Visualize newlines if they matter

### DIFF
--- a/examples/newlines-matter.rs
+++ b/examples/newlines-matter.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let reference = "foo\r\nbar";
+    similar_asserts::assert_eq!(reference, "foo\nbar");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,11 +115,11 @@ impl<'a> SimpleDiff<'a> {
 }
 
 fn trailing_newline(s: &str) -> &str {
-    if let Some(_) = s.strip_suffix("\r\n") {
+    if s.ends_with("\r\n") {
         "\r\n"
-    } else if let Some(_) = s.strip_suffix("\r") {
+    } else if s.ends_with("\r") {
         "\r"
-    } else if let Some(_) = s.strip_suffix("\n") {
+    } else if s.ends_with("\n") {
         "\n"
     } else {
         ""


### PR DESCRIPTION
This adds visualization if differences are newlines that are not rendered properly.

<img width="1035" alt="image" src="https://user-images.githubusercontent.com/7396/182716221-679de6a4-b766-4704-a996-f6479b0d2e3d.png">
