### PR TITLE
Remove stray ' in fail_assertion() panic-message

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,7 +202,7 @@ impl<'a> SimpleDiff<'a> {
         let (right, right_truncated) = truncate_str(&self.right_short, len);
 
         panic!(
-            "assertion failed: `({} == {})`{}'\
+            "assertion failed: `({} == {})`{}\
                \n {:>label_padding$}: `{:?}`{}\
                \n {:>label_padding$}: `{:?}`{}\
                \n\n{}\n",


### PR DESCRIPTION
Since there is no matching pair it seems like an accident?

### Before the fix (using [examples/extended.rs](https://github.com/mitsuhiko/similar-asserts/blob/c1a9130bdebaeb74fc09cd16c572b0972016f4e7/examples/extended.rs)):

```console
$ cargo run --example extended

thread 'main' panicked at examples/extended.rs:11:5:
assertion failed: `(expected == actual)`: some stuff here 42'
 expected: `"[(Major, 2), (Minor, 20), (Value, 0)]"`
   actual: `"[(Major, 2), (Minor, 0), (Value, 0), (Value, 1)]"`

Differences (-expected|+actual):
```

### After the fix:

```console
$ cargo run --example extended

thread 'main' panicked at examples/extended.rs:11:5:
assertion failed: `(expected == actual)`: some stuff here 42
 expected: `"[(Major, 2), (Minor, 20), (Value, 0)]"`
   actual: `"[(Major, 2), (Minor, 0), (Value, 0), (Value, 1)]"`

Differences (-expected|+actual):
```

Thanks for this project!