### PR TITLE
Remove stray ' from assertion failure message.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,7 +202,7 @@ impl<'a> SimpleDiff<'a> {
         let (right, right_truncated) = truncate_str(&self.right_short, len);
 
         panic!(
-            "assertion failed: `({} == {})`{}'\
+            "assertion failed: `({} == {})`{}\
                \n {:>label_padding$}: `{:?}`{}\
                \n {:>label_padding$}: `{:?}`{}\
                \n\n{}\n",


### PR DESCRIPTION
Previously, you'd get output like this:

```
assertion failed: `(left == right)`'
                                   ^--stray quote
```

This quote seems to be stray. So removing it.